### PR TITLE
Change the damage cause for projectile that apply for new bukkit damage ...

### DIFF
--- a/src/bone008/bukkit/deathcontrol/DeathCause.java
+++ b/src/bone008/bukkit/deathcontrol/DeathCause.java
@@ -97,9 +97,7 @@ public enum DeathCause {
 			if(cause == DamageCause.ENTITY_ATTACK && (event instanceof EntityDamageByEntityEvent)){
 				EntityDamageByEntityEvent eEvent = (EntityDamageByEntityEvent)event;
 				Entity damager = eEvent.getDamager();
-				if(damager instanceof Projectile)
-					damager = ((Projectile)damager).getShooter();
-				
+
 				if(damager instanceof Player)
 					return DeathCause.PLAYER;
 				if(damager instanceof Wolf)
@@ -108,7 +106,21 @@ public enum DeathCause {
 					return DeathCause.MOB;
 				return DeathCause.UNKNOWN;
 			}
-			
+			// add support for new Bukkit API
+			if(cause == DamageCause.PROJECTILE && (event instanceof EntityDamageByEntityEvent)){
+				EntityDamageByEntityEvent eEvent = (EntityDamageByEntityEvent)event;
+				Entity damager = eEvent.getDamager();
+				damager = ((Projectile)damager).getShooter();
+				
+				if(damager instanceof Player)
+					return DeathCause.PLAYER;
+				if(damager instanceof Wolf)
+					return DeathCause.MOB_WOLF;
+				if(damager instanceof LivingEntity)
+					return DeathCause.MOB;
+				
+				return DeathCause.UNKNOWN;
+			}
 			
 			// if no special case matched, check for a direct match
 			try{


### PR DESCRIPTION
Your plugin cannot apply for new bukkit 1.2.4-Rx
The shooter of projectile cannot be detected correctly.
I checked your code and change something in damage cause so that it works right on bukkit-1.2.5-R0.

I wish you can allow me to push this and update a new version.
Thx
